### PR TITLE
ci: automate marketplace publishing on version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,99 @@
+name: Publish
+
+# Publishes the extension when you push a version tag (e.g. `v1.3.0`).
+# Requires repository secrets:
+#   VSCE_PAT  (required) — Azure DevOps PAT with Marketplace > Manage scope
+#   OVSX_PAT  (optional) — Open VSX token; if unset, Open VSX is skipped
+#
+# Release flow:
+#   1. bump "version" in package.json (e.g. 1.3.1) and commit to main
+#   2. git tag v1.3.1 && git push origin v1.3.1
+# The tag must match package.json's version or the run fails before publishing.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Build and validate only, do not publish'
+        type: boolean
+        default: false
+
+# Never run two publishes at once.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # to create the GitHub Release and upload the VSIX
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      OVSX_PAT: ${{ secrets.OVSX_PAT }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Resolve version
+        id: meta
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag matches package.json version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="${{ steps.meta.outputs.version }}"
+          echo "tag=$TAG package.json=$PKG"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Tag v$TAG does not match package.json version $PKG. Bump package.json and re-tag."
+            exit 1
+          fi
+
+      - name: Package VSIX
+        run: npx @vscode/vsce package --out "auto-git-copilot-${{ steps.meta.outputs.version }}.vsix"
+
+      - name: Publish to VS Code Marketplace
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npx @vscode/vsce publish --packagePath "auto-git-copilot-${{ steps.meta.outputs.version }}.vsix"
+
+      - name: Publish to Open VSX
+        if: ${{ github.event.inputs.dry_run != 'true' && env.OVSX_PAT != '' }}
+        run: npx ovsx publish "auto-git-copilot-${{ steps.meta.outputs.version }}.vsix" -p "$OVSX_PAT"
+
+      - name: Upload VSIX as a workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: auto-git-copilot-${{ steps.meta.outputs.version }}
+          path: auto-git-copilot-${{ steps.meta.outputs.version }}.vsix
+
+      - name: Create GitHub Release
+        if: ${{ startsWith(github.ref, 'refs/tags/') && github.event.inputs.dry_run != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            "auto-git-copilot-${{ steps.meta.outputs.version }}.vsix" \
+            --title "v${{ steps.meta.outputs.version }}" \
+            --generate-notes

--- a/BUILD_INSTRUCTIONS.md
+++ b/BUILD_INSTRUCTIONS.md
@@ -57,14 +57,44 @@ Alternatively run `rebuild.bat` on Windows to do steps 3–4 in one go.
 4. Toggle it on, save a file, and watch: `Pending (1)` → `Working...` → `ON`
 5. Check `git log --oneline -3` for the new commit
 
-## Publishing to the Marketplace (optional)
+## Publishing to the Marketplace
 
-1. Create a publisher account: https://marketplace.visualstudio.com/manage
-2. Get a Personal Access Token from Azure DevOps
-3. ```bash
-   npx @vscode/vsce login <publisher-name>
-   npx @vscode/vsce publish
-   ```
+Publishing is automated by [`.github/workflows/publish.yml`](.github/workflows/publish.yml).
+It runs on any version tag (`v*.*.*`): it lints, type-checks, and tests, verifies
+the tag matches `package.json`, packages the VSIX, publishes to the VS Code
+Marketplace (and Open VSX if configured), and attaches the VSIX to a GitHub
+Release.
+
+### One-time setup
+
+1. Create a publisher (`ShreyaBoyane`) at https://marketplace.visualstudio.com/manage
+2. Create an Azure DevOps **Personal Access Token** with the *Marketplace →
+   Manage* scope
+3. Add it as a repository secret named **`VSCE_PAT`**
+   (GitHub repo → Settings → Secrets and variables → Actions → New repository secret)
+4. *(Optional, for Cursor / VSCodium / Windsurf users)* create an
+   [Open VSX](https://open-vsx.org/) token and add it as **`OVSX_PAT`**. If this
+   secret is absent, the Open VSX step is skipped automatically.
+
+### Cutting a release
+
+```bash
+# 1. Bump the version in package.json (e.g. 1.3.0 -> 1.3.1) and commit to main
+# 2. Tag and push — this triggers the publish workflow:
+git tag v1.3.1
+git push origin v1.3.1
+```
+
+The tag **must** match `package.json`'s `version` or the workflow fails before
+publishing anything. To rehearse without publishing, run the workflow manually
+from the Actions tab with **Run workflow → dry_run = true**.
+
+### Manual publish (fallback)
+
+```bash
+npx @vscode/vsce login ShreyaBoyane   # paste your PAT once
+npx @vscode/vsce publish              # publishes the version in package.json
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION
Add .github/workflows/publish.yml: on any `v*.*.*` tag it lints, type-checks, tests, verifies the tag matches package.json, packages the VSIX, publishes to the VS Code Marketplace (VSCE_PAT) and, if configured, Open VSX (OVSX_PAT), then attaches the VSIX to a GitHub Release. Supports a dry_run via workflow_dispatch. Documents the release flow and required secrets in BUILD_INSTRUCTIONS.md.